### PR TITLE
Change FROM image to Red Hat Universal Base Image (UBI) 8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 # Copyright DataStax, Inc.
 # Please see the included license file for details.
 
-# FROM openjdk:8u212-jre-slim-stretch
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf update && rm -rf /var/cache/yum

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,11 @@
 # Copyright DataStax, Inc.
 # Please see the included license file for details.
 
-FROM openjdk:8u212-jre-slim-stretch
+# FROM openjdk:8u212-jre-slim-stretch
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf update && rm -rf /var/cache/yum
+RUN microdnf install java-1.8.0-openjdk && microdnf clean all
 
 ENV USER_UID=1001 \
     USER_NAME=cass-operator \


### PR DESCRIPTION
This PR changes the FROM Dockerfile lines to registry.access.redhat.com/ubi8/ubi-minimal:latest.

Additionally, adjustments have been made given the shift from the Debian base to Red Hat.