### PR TITLE
Miles/client backpressure  [K8SSAND-723]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build
 .gradle
+/target
+/.idea
+/.vscode
+/.bloop

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Variable|Description
 ---|---
 CONFIG_FILE_DATA|See below for explanation
 CONFIG_OUTPUT_DIRECTORY|Filesystem location to place rendered files.  Defaults to /config
-DEFINITION_LOCATION|Filesystem location of the Definition Files.  Defaults to /definitions
+DEFINITIONS_LOCATION|Filesystem location of the Definition Files.  Defaults to /definitions
 POD_IP|The IP of the Kubernetes Pod
 HOST_IP|The IP of the Kubernetes worker hosting the Pod
 PRODUCT_NAME|Either "cassandra" or "dse"


### PR DESCRIPTION
Some conveniences added while working on cass-config-definitions PR [64](https://github.com/datastax/cass-config-definitions/pull/64).

1. The README was incorrect; references to `DEFINITION_LOCATION` should read `DEFINITIONS_LOCATION`.
2. `.gitignore` could ignore more IDE cruft. This is obviously dependant on everyone's individual environments but thought I'd do my bit.