### PR TITLE
Use ubi8 images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:7.8 AS builder-ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS builder-ubi
 
 # Update the builder packages and create user
 RUN microdnf update && rm -rf /var/cache/yum && \
@@ -43,7 +43,7 @@ RUN microdnf update && rm -rf /var/cache/yum && \
 
 #############################################################
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:7.8 as cass-config-builder-ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as cass-config-builder-ubi
 
 LABEL maintainer="DataStax, Inc <info@datastax.com>"
 LABEL name="cass-config-builder"


### PR DESCRIPTION
Usage newer images helps to fix critical CVE existed in current versions.
Fixes: #36
Signed-off-by: akamyshnikova <akamyshnikova@mirantis.com>