### PR TITLE
-ubi7 should be pushed with linux/arm64 build also

### DIFF
--- a/scripts/push-release.sh
+++ b/scripts/push-release.sh
@@ -52,7 +52,7 @@ UBI_ARGS=(
 docker buildx build --push \
   "${DOCKERHUB_UBI_TAGS[@]}" \
   "${UBI_ARGS[@]}" \
-  --platform linux/amd64 .
+  --platform linux/amd64,linux/arm64 .
 
 docker buildx build --push \
   "${DOCKERHUB_TAGS[@]}" \


### PR DESCRIPTION
We won't push the -ubi7 tag with linux/arm64 build at the moment, only the 1.0.